### PR TITLE
Fix incorrect return value

### DIFF
--- a/lua/galaxyline/providers/diagnostic.lua
+++ b/lua/galaxyline/providers/diagnostic.lua
@@ -4,7 +4,7 @@ local diagnostic = {}
 local function get_coc_diagnostic(diag_type)
   local has_info, info = pcall(vim.api.nvim_buf_get_var, 0, "coc_diagnostic_info")
   if not has_info then
-    return
+    return 0
   end
 
   return info[diag_type]

--- a/lua/galaxyline/providers/diagnostic.lua
+++ b/lua/galaxyline/providers/diagnostic.lua
@@ -4,7 +4,7 @@ local diagnostic = {}
 local function get_coc_diagnostic(diag_type)
   local has_info, info = pcall(vim.api.nvim_buf_get_var, 0, "coc_diagnostic_info")
   if not has_info then
-    return 0
+    return ""
   end
 
   return info[diag_type]


### PR DESCRIPTION
Currently migrating over to this fork and encountering the following error when opening a file with no diagnostic info (from coc):

```
.../galaxyline.nvim/lua/galaxyline/providers/diagnostic.lua:45: attempt to concatenate local 'coun
t' (a nil value)
E15: Invalid expression: luaeval('require("galaxyline").component_decorator')("DiagnosticError")
.../galaxyline.nvim/lua/galaxyline/providers/diagnostic.lua:45: attempt to concatenate local 'coun
t' (a nil value) function: builtin#18 .../galaxyline.nvim/lua/galaxyline/providers/diagnostic.lua:
45: attempt to concatenate local 'count' (a nil value)
.../galaxyline.nvim/lua/galaxyline/providers/diagnostic.lua:45: attempt to concatenate local 'coun
t' (a nil value) function: builtin#18 .../galaxyline.nvim/lua/galaxyline/providers/diagnostic.lua:
45: attempt to concatenate local 'count' (a nil value) function: builtin#18 .../galaxyline.nvim/lu
a/galaxyline/providers/diagnostic.lua:45: attempt to concatenate local 'count' (a nil value)
E15: Invalid expression: luaeval('require("galaxyline").component_decorator')("DiagnosticInfo")
Press ENTER or type command to continue
```

Having it return `""` just like `get_nvim_lsp_diagnostic` seems to fix the issue 👍🏼 