### PR TITLE
Return nil if there are no diagnostics

### DIFF
--- a/lua/galaxyline/providers/diagnostic.lua
+++ b/lua/galaxyline/providers/diagnostic.lua
@@ -4,7 +4,7 @@ local diagnostic = {}
 local function get_coc_diagnostic(diag_type)
   local has_info, info = pcall(vim.api.nvim_buf_get_var, 0, "coc_diagnostic_info")
   if not has_info then
-    return ""
+    return
   end
 
   return info[diag_type]
@@ -42,6 +42,9 @@ end
 
 local function get_formatted_diagnostic(diag_type)
   local count = diagnostic.get_diagnostic(diag_type)
+  if not count then
+    return
+  end
   return count ~= 0 and count .. " " or ""
 end
 


### PR DESCRIPTION
Sorry @NTBBloodbath, realized the behaviour was not quite right. When `count` is nil we were returning an empty string which caused the diagnostic component to be shown like this:

![image](https://user-images.githubusercontent.com/8370058/133864509-50c3fa2b-bcce-4ac2-8947-234fffeadf5c.png)

By explicitly returning `nil` we make sure the sections are hidden when there are no diagnostic results

Let me know if the change breaks the LSP client implementation 😅 