### PR TITLE
fix(providers): return the `bufnr` instead of the buffer index

### DIFF
--- a/lua/galaxyline/providers/buffer.lua
+++ b/lua/galaxyline/providers/buffer.lua
@@ -23,18 +23,7 @@ end
 
 -- get buffer number
 buffer.get_buffer_number = function()
-  local buffers = {}
-  for _, val in ipairs(vim.fn.range(1, vim.fn.bufnr("$"))) do
-    if vim.fn.bufexists(val) == 1 and vim.fn.buflisted(val) == 1 then
-      table.insert(buffers, val)
-    end
-  end
-
-  for idx, nr in ipairs(buffers) do
-    if nr == vim.fn.bufnr("") then
-      return idx
-    end
-  end
+  return vim.api.nvim_win_get_buf(0)
 end
 
 return buffer


### PR DESCRIPTION
Return the actual `bufnr` as opposed to the index of listed buffers. Now you will get the buffer number as seen when running `:ls`. Maybe there was a good reason for wanting this index but it seemed to be that users would expect `bufnr`. You can use `bufnr` for `[N]` when using `:buffer [N]` and alike. I don't know what you can do with that index returned now. If I have misunderstood the provider's use case, then apologies. My intent is to fix, not cause breaking changes on expected behavior. 😄 

I hope this adds value for users. It certainly has helped me. Thanks again for forking and maintaining @NTBBloodbath 👍🏼 

Reference: https://github.com/neovim/neovim/search?q=nvim_win_get_buf 