### PR TITLE
fixing check_active_lsp, which had been logically flipped

### DIFF
--- a/lua/galaxyline/condition.lua
+++ b/lua/galaxyline/condition.lua
@@ -39,7 +39,7 @@ end
 
 condition.check_active_lsp = function()
   local clients = vim.lsp.buf_get_clients()
-  return next(clients) == nil
+  return next(clients) != nil
 end
 
 return condition

--- a/lua/galaxyline/condition.lua
+++ b/lua/galaxyline/condition.lua
@@ -39,7 +39,7 @@ end
 
 condition.check_active_lsp = function()
   local clients = vim.lsp.buf_get_clients()
-  return next(clients) == nil
+  return next(clients) ~= nil
 end
 
 return condition


### PR DESCRIPTION
check_active_lsp had been logically flipped in https://github.com/NTBBloodbath/galaxyline.nvim/commit/7cbfbe2702902da612b7cc9ba46bf4ee54ec80ad. This change reverses it back to the original logic. 