### PR TITLE
feat: Allow highlight groups to be updated.

### DIFF
--- a/lua/galaxyline.lua
+++ b/lua/galaxyline.lua
@@ -181,12 +181,8 @@ local function load_section(section_area, pos)
       section = section .. ls
       local group = "Galaxy" .. component_name
       local sgroup = component_name .. "Separator"
-      if not hi_tbl[group] then
-        hi_tbl[group] = component_info.highlight or {}
-      end
-      if not hi_tbl[sgroup] then
-        hi_tbl[sgroup] = component_info.separator_highlight or {}
-      end
+      hi_tbl[group] = component_info.highlight or {}
+      hi_tbl[sgroup] = component_info.separator_highlight or {}
       if component_info.event and vim.fn.index(events, component_info.event) == -1 then
         events[#events + 1] = component_info.event
       end

--- a/lua/galaxyline/highlighting.lua
+++ b/lua/galaxyline/highlighting.lua
@@ -54,7 +54,7 @@ local function set_highlight(group, hi_info)
     style = hi_info[3] and _switch[type(hi_info[3])](style, hi_info[3]) or ""
   end
 
-  vim.api.nvim_command("highlight " .. group .. " " .. fg .. " " .. bg .. " " .. style)
+  vim.api.nvim_command("highlight! " .. group .. " " .. fg .. " " .. bg .. " " .. style)
 end
 
 function highlights.init_theme(hi_tbl)


### PR DESCRIPTION
Thank you for taking up the maintenance of this plugin.

This is a modification I've been using in my own fork for a while. It's a simple change that allows the highlight groups to be redefined upon calling `require('galaxyline').load_galaxyline()`. This allows me to automatically, properly update the highlights on the `ColorScheme` event.