### PR TITLE
fix: diag_type error occurs on coc.nvim

### DIFF
--- a/lua/galaxyline/providers/diagnostic.lua
+++ b/lua/galaxyline/providers/diagnostic.lua
@@ -2,12 +2,18 @@ local diagnostic = {}
 
 -- coc diagnostic
 local function get_coc_diagnostic(diag_type)
+	local coc_diag_types = {
+		'error',
+		'warning',
+		'information',
+		'hint',
+	}
 	local has_info, info = pcall(vim.api.nvim_buf_get_var, 0, "coc_diagnostic_info")
 	if not has_info then
 		return
 	end
 
-	return info[diag_type]
+	return info[coc_diag_types[diag_type]]
 end
 
 -- nvim-lspconfig
@@ -31,7 +37,7 @@ diagnostic.get_diagnostic = function(diag_type)
 	local count = 0
 
 	if vim.fn.exists("*coc#rpc#start_server") == 1 then
-		count = get_coc_diagnostic(diag_type:lower())
+		count = get_coc_diagnostic(diag_type)
 	elseif not vim.tbl_isempty(vim.lsp.buf_get_clients(0)) then
 		count = get_nvim_lsp_diagnostic(diag_type)
 	end


### PR DESCRIPTION
I get an error when using Coc. Because `vim.diagnostic.severity.ERROR` is a number, but it uses the lower()