### PR TITLE
feat: specify servers to ignore for GetLspClient provider

### DIFF
--- a/lua/galaxyline/providers/lsp.lua
+++ b/lua/galaxyline/providers/lsp.lua
@@ -1,5 +1,7 @@
-local get_lsp_client = function(msg)
+local get_lsp_client = function(msg, ignored_servers)
   msg = msg or "No Active Lsp"
+  ignored_servers = ignored_servers or {}
+
   local clients = vim.lsp.buf_get_clients()
   if next(clients) == nil then
     return msg
@@ -7,10 +9,12 @@ local get_lsp_client = function(msg)
 
   local client_names = ""
   for _, client in pairs(clients) do
-    if string.len(client_names) < 1 then
-      client_names = client_names .. client.name
-    else
-      client_names = client_names .. ", " .. client.name
+    if not vim.tbl_contains(ignored_servers, client.name) then
+      if string.len(client_names) < 1 then
+        client_names = client_names .. client.name
+      else
+        client_names = client_names .. ", " .. client.name
+      end
     end
   end
   return string.len(client_names) > 0 and client_names or msg


### PR DESCRIPTION
This adds the options to specific servers to be ignore, i.e. not displayed from the GetLspClient provider. Users can pass in a table of server names to ignore into the provider's function to enable this, e.g.
```lua
{
  LspClient = {
    provider = function()
      return require("galaxyline.providers.lsp").get_lsp_client("", { "null-ls" })
    end,
  },
},

```